### PR TITLE
  macOS, add support for PKG background images in dark mode.

### DIFF
--- a/src/templates/macos/distribution.xml.ts
+++ b/src/templates/macos/distribution.xml.ts
@@ -15,6 +15,7 @@ export default (opts) => `<?xml version="1.0" encoding="utf-8"?>
   <welcome mime-type="text/html" file="WELCOME.html"/>
   <license mime-type="text/html" file="LICENSE.html"/>
   <background file="background.png" alignment="bottomleft" scaling="none"/>
+  <background-darkAqua file="background-darkAqua.png" alignment="bottomleft" scaling="none"/>
   <title>${opts.name}</title>
 </installer-gui-script>
 `


### PR DESCRIPTION
It happens that pkg installer also supports a dark mode.
So when you add background image and build your installer you will got an empty image while dark mode is beeing active.

Solution is easy, just to add a new xml option - `background-darkAqua`.
I must say that it is better to make your dark using transparent background because OS' theme Accent Color also changes background color. There are only two accents that will change the background color: Blue (the accents range from blue to the green) and Graphite.

Also would be nice to add note about this options somewhere in the docs and maybe some comment inside [cep-starter/cep-config.js](https://github.com/adobe-extension-tools/cep-starter/blob/master/cep-config.js)

Related links:

- https://github.com/electron-userland/electron-builder/pull/4489/files
- https://forums.developer.apple.com/thread/108056
- https://stackoverflow.com/questions/56349772/how-to-set-background-image-in-macos-mojave-pkg-installer-using-productbuild